### PR TITLE
Add notice in readme of archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sonobuoy systemd-logs plugin
 
+> NOTE: This repository is no longer actively maintained. The project has moved to [github.com/vmware-tanzu/sonobuoy-plugins](https://github.com/vmware-tanzu/sonobuoy-plugins)
+
 This is a simple standalone container that gathers log information from systemd, by chrooting into the node's filesystem and running `journalctl`.
 
 This container is used by [Heptio Sonobuoy](https://github.com/heptio/sonobuoy) for gathering host logs in a Kubernetes cluster.


### PR DESCRIPTION
We have moved this code into vmware-tanzu/sonobuoy-plugins and
so we can archive this repo. Per github recommendations, we should
update the README and close issues/tickets before doing so.

Signed-off-by: John Schnake <jschnake@vmware.com>